### PR TITLE
Ignore Python Virtual Environment (venv) files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,8 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Virtual environment files
+bin
+**/pyvenv.cfg
+include


### PR DESCRIPTION
Modify .gitignore to ignore Python Virtual Environment (venv) files.